### PR TITLE
Better nested arithmetic exprs

### DIFF
--- a/src/l4_lp/syntax/l4_to_prolog.cljc
+++ b/src/l4_lp/syntax/l4_to_prolog.cljc
@@ -80,8 +80,8 @@
     ;; --------------------------------------------------
     ;; ⟦(DECIDE ?head₀ ... ?headₘ IF ?body₀ ... ?bodyₙ)⟧ =
     ;;   ⟦(:- (?head₀ ... ?headₘ) (?body₀ ... ?bodyₙ))⟧
-    (DECIDE & ?head (m/pred #{'IF 'WHEN 'WHERE}) . !body ..1)
-    ((~(symbol ":-") ?head (!body ...)))
+    (DECIDE . !head ..1 (m/pred #{'IF 'WHEN 'WHERE}) . !body ..1)
+    ((~(symbol ":-") (!head ...) (!body ...)))
 
     (m/pred (every-pred seq? #(some #{'AND 'OR} %)) ?xs)
     ~(->> ?xs
@@ -237,7 +237,7 @@
 
     ;; ---------------------------------------
     ;;  ⟦[?x₀ ... ?xₙ]⟧ = [⟦?x₀⟧ , ... , ⟦?xₙ⟧]
-    [!xs ... !x] [!xs ~(symbol ",") ... !x]
+    [!xs ... ?x] [!xs ~(symbol ",") ... ?x]
 
     ;; ?var-name = (symbol "var" ?var-name')
     ;; -----------------------------------------------------

--- a/src/l4_lp/syntax/l4_to_prolog.cljc
+++ b/src/l4_lp/syntax/l4_to_prolog.cljc
@@ -80,8 +80,8 @@
     ;; --------------------------------------------------
     ;; ⟦(DECIDE ?head₀ ... ?headₘ IF ?body₀ ... ?bodyₙ)⟧ =
     ;;   ⟦(:- (?head₀ ... ?headₘ) (?body₀ ... ?bodyₙ))⟧
-    (DECIDE . !head ..1 (m/pred #{'IF 'WHEN 'WHERE}) . !body ..1)
-    ((~(symbol ":-") (!head ...) (!body ...)))
+    (DECIDE & ?head (m/pred #{'IF 'WHEN 'WHERE}) . !body ..1)
+    ((~(symbol ":-") ?head (!body ...)))
 
     (m/pred (every-pred seq? #(some #{'AND 'OR} %)) ?xs)
     ~(->> ?xs
@@ -91,28 +91,44 @@
                           ?x (sequence ?x))))
           sequence)
 
-    ;; WIP: Expand nested computations
-    ;;
     ;; ?op ∈ {MIN MAX PRODUCT SUM}
+    ;; ?comparison ∈ {'IS 'EQUALS '= '== '< '<= '=< '> '>=}
     ;; ⊢ symbol? ?arg ∨ ∀ x ∈ ?arg, symbol? x ∨ number? x
     ;; ?var is a fresh variable
-    ;; (?C, λx. throw (cont C) x) ⊢ (?C ?var) ⇓ ?e
-    ;; -----------------------------------------------------------------------
-    ;; ⟦(?lhs IS C[(?op ?arg)]⟧ = ((?var IS ?op OF ?arg) AND (?lhs IS ?e))⟧
-    (m/and
-     (?lhs
-      IS & (m/$ ?C
-                ((m/pred #{'MIN 'MAX 'PRODUCT 'SUM} ?op)
-                 & (m/or
-                    (m/seqable
-                     (m/or (m/and (m/symbol _) ?arg)
-                           (m/and [& _]
-                                  (m/pred #(every? (some-fn symbol? number?) %))
-                                  ?arg)))
-                    (m/pred #(every? (some-fn symbol? number?) %)
-                            (m/app #(into [] %) ?arg))))))
-     (m/let [?var (gensym "var/var__")]))
-    ((?var IS ~(symbol "OP" ?op) ?arg) AND (?lhs IS ~(?C ?var)))
+    ;; (?C, λx. throw (cont C) x) ⊢ (?C ?var) ⇓ ?rhs
+    ;; --------------------------------------------------------------------------------------
+    ;; ⟦(?lhs ?comparison C[(?op ?arg)]⟧ = ((?var IS ?op OF ?arg) AND (?lhs ?comparison ?rhs))⟧
+
+    ;; ?op ∈ {MIN MAX PRODUCT SUM}
+    ;; ?comparison ∈ {'IS 'EQUALS '= '== '< '<= '=< '> '>=}
+    ;; ⊢ symbol? ?arg ∨ ∀ x ∈ ?arg, symbol? x ∨ number? x
+    ;; ?var is a fresh variable
+    ;; (?C, λx. throw (cont C) x) ⊢ (?C ?var) ⇓ ?lhs
+    ;; --------------------------------------------------------------------------------------
+    ;; ⟦(C[(?op ?arg)] ?comparison ?rhs⟧ = ((?var IS ?op OF ?arg) AND (?lhs ?comparison ?rhs))⟧
+    (m/with
+     [%nested-arithmetic-expr
+      (m/$ ?C ((m/pred #{'MIN 'MAX 'PRODUCT 'SUM} ?op)
+               & (m/or
+                  (m/seqable
+                   (m/or (m/and (m/symbol _) ?arg)
+                         (m/and [& _]
+                                (m/pred #(every? (some-fn symbol? number?) %))
+                                ?arg)))
+                  (m/pred #(every? (some-fn symbol? number?) %)
+                          (m/app #(into [] %) ?arg)))))
+      %comparison
+      (m/pred #{'IS 'EQUALS '= '== '< '<= '=< '> '>=} ?comparison)]
+
+     (m/and
+      (m/let [?var (gensym "var/var__")])
+      (m/or
+       (m/and (& ?lhs %comparison & %nested-arithmetic-expr)
+              (m/let [?rhs (?C ?var)]))
+       (m/and (& %nested-arithmetic-expr %comparison & ?rhs)
+              (m/let [?lhs (?C ?var)])))))
+
+    ((?var IS ~(symbol "OP" ?op) ?arg) AND (?lhs ?comparison ?rhs))
 
     ;; -------------------------------------------------
     ;; ⟦(DECIDE ?head₀ ... ?headₙ)⟧ = ⟦(?head₀ ... ?headₙ)⟧

--- a/src/l4_lp/syntax/mixfix_parser.cljc
+++ b/src/l4_lp/syntax/mixfix_parser.cljc
@@ -29,7 +29,7 @@
     {:pred (symbol ?l4-symbol) :args ?args}
 
     {:non-args (m/some ?non-args) :args ?args}
-    {:pred (it-> ?non-args (str/join "_" it) (str "'" it "'") (symbol it))
+    {:pred (it-> ?non-args (str/join " " it) (str "'" it "'") (symbol it))
      :args ?args}))
 
 (def ^:private pred-atom+args->prolog-prefix-ast

--- a/src/l4_lp/webeditor/main.cljs
+++ b/src/l4_lp/webeditor/main.cljs
@@ -15,7 +15,7 @@
 ;;   traces, runs directly in the browser.
 
 DECIDE query
-WHEN 3 IS SUM 0 1 (MIN (SUM 0 3) 2)
+WHEN MIN 0 (SUM 1 2) < PRODUCT (MAX 3 4) 5
 
 GIVEN (x IS A Number)
 DECIDE x is between 0 and 10 or is 100


### PR DESCRIPTION
Generalise parsing of nested arithmetic expressions so that it works for:
- exprs on the LHS and not just the RHS of `IS`.
- other kinds of arithmetic comparisons, like `<` and `>` and not just `IS`.