### PR TITLE
temporarily downgrade swipl wasm

### DIFF
--- a/src/l4_lp/swipl/js/wasm_query.cljs
+++ b/src/l4_lp/swipl/js/wasm_query.cljs
@@ -3,7 +3,7 @@
             [cljs-bean.core :as bean]
             [l4-lp.swipl.js.common.swipl-js-to-clj :as swipl-js->clj]
             [promesa.core :as prom]
-            ["https://SWI-Prolog.github.io/npm-swipl-wasm/3/7/7/dynamic-import.js"
+            ["https://SWI-Prolog.github.io/npm-swipl-wasm/3/7/5/dynamic-import.js"
              :rename {SWIPL Swipl}]))
 
 (def ^:private prelude-qlf-url


### PR DESCRIPTION
Downgrade the Swipl version running in WASM to match the one that was used to generate the qlf files.
This eliminates the following error which shows up in the JS console at runtime:
```ERROR: https://smucclaw.github.io/l4-lp/resources/swipl/prelude.qlf: Invalid QLF file: incompatible VM-signature (file: 0x408bfff4; Prolog: 0x6ed28fea)```