### PR TITLE
try pinning swipl version in web editor workflow

### DIFF
--- a/.github/workflows/browser_esm_lib.yml
+++ b/.github/workflows/browser_esm_lib.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +52,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8.15.5
+          version: 8.15.6
           run_install: false
 
       - name: Get pnpm store directory
@@ -75,7 +75,7 @@ jobs:
         uses: smucclaw/setup-swi-prolog@master
         with:
           swi-prolog-branch: devel
-          swi-prolog-version: latest
+          swi-prolog-version: '9.3.3-2-gc2f390bcc-jammyppa2'
 
       - name: Install SWI-Prolog dependencies
         run: |

--- a/.github/workflows/jvm_lib.yml
+++ b/.github/workflows/jvm_lib.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -53,14 +53,14 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8.15.5
+          version: 8.15.6
           run_install: false
 
       - name: Setup SWI-Prolog
         uses: smucclaw/setup-swi-prolog@master
         with:
           swi-prolog-branch: devel
-          swi-prolog-version: latest
+          swi-prolog-version: '9.3.3-2-gc2f390bcc-jammyppa2'
 
       - name: Install SWI-Prolog dependencies
         run: |

--- a/.github/workflows/node_lib.yml
+++ b/.github/workflows/node_lib.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +52,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8.15.5
+          version: 8.15.6
           run_install: false
 
       - name: Get pnpm store directory
@@ -75,7 +75,7 @@ jobs:
         uses: smucclaw/setup-swi-prolog@master
         with:
           swi-prolog-branch: devel
-          swi-prolog-version: latest
+          swi-prolog-version: '9.3.3-2-gc2f390bcc-jammyppa2'
 
       - name: Install SWI-Prolog dependencies
         run: |

--- a/.github/workflows/py_node_lib.yml
+++ b/.github/workflows/py_node_lib.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +52,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8.15.5
+          version: 8.15.6
           run_install: false
 
       - name: Get pnpm store directory
@@ -75,7 +75,7 @@ jobs:
         uses: smucclaw/setup-swi-prolog@master
         with:
           swi-prolog-branch: devel
-          swi-prolog-version: latest
+          swi-prolog-version: '9.3.3-2-gc2f390bcc-jammyppa2'
 
       - name: Install SWI-Prolog dependencies
         run: |

--- a/.github/workflows/web_editor.yml
+++ b/.github/workflows/web_editor.yml
@@ -75,7 +75,7 @@ jobs:
         uses: smucclaw/setup-swi-prolog@master
         with:
           swi-prolog-branch: devel
-          swi-prolog-version: '9.3.3-3'
+          swi-prolog-version: 'V9.3.3'
 
       - name: Install SWI-Prolog dependencies
         run: |

--- a/.github/workflows/web_editor.yml
+++ b/.github/workflows/web_editor.yml
@@ -75,7 +75,7 @@ jobs:
         uses: smucclaw/setup-swi-prolog@master
         with:
           swi-prolog-branch: devel
-          swi-prolog-version: '9.3.3-3-ge0cef5118-manticppa2'
+          swi-prolog-version: '9.3.3'
 
       - name: Install SWI-Prolog dependencies
         run: |

--- a/.github/workflows/web_editor.yml
+++ b/.github/workflows/web_editor.yml
@@ -75,7 +75,7 @@ jobs:
         uses: smucclaw/setup-swi-prolog@master
         with:
           swi-prolog-branch: devel
-          swi-prolog-version: latest
+          swi-prolog-version: '9.3.3-3-ge0cef5118-manticppa2'
 
       - name: Install SWI-Prolog dependencies
         run: |

--- a/.github/workflows/web_editor.yml
+++ b/.github/workflows/web_editor.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +52,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8.15.5
+          version: 8.15.6
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/web_editor.yml
+++ b/.github/workflows/web_editor.yml
@@ -75,7 +75,7 @@ jobs:
         uses: smucclaw/setup-swi-prolog@master
         with:
           swi-prolog-branch: devel
-          swi-prolog-version: 'V9.3.3'
+          swi-prolog-version: '9.3.3-2-gc2f390bcc-jammyppa2'
 
       - name: Install SWI-Prolog dependencies
         run: |

--- a/.github/workflows/web_editor.yml
+++ b/.github/workflows/web_editor.yml
@@ -75,7 +75,7 @@ jobs:
         uses: smucclaw/setup-swi-prolog@master
         with:
           swi-prolog-branch: devel
-          swi-prolog-version: '9.3.3'
+          swi-prolog-version: '9.3.3-3'
 
       - name: Install SWI-Prolog dependencies
         run: |


### PR DESCRIPTION
This updates GitHub workflows to be more robust by pinning Ubuntu and SWI-Prolog versions used in workflows to build artifacts.
More precisely, this includes the following changes:
- Pin Ubuntu version to `ubuntu-22.04` (previously was `ubuntu-latest`)
- Pin SWI-Prolog version to `9.3.3-2-gc2f390bcc-jammyppa2' (previously was`latest`)
- Update `pnpm` from `8.15.5` to `8.15.6`