### PR TITLE
cleanup tracing of swipl queries

### DIFF
--- a/public/resources/swipl/prelude.pl
+++ b/public/resources/swipl/prelude.pl
@@ -7,8 +7,6 @@
 :- use_module(library(macros)).
 :- use_module(library(dicts)).
 
-% :- use_module(library(clpq)).
-
 :- [library(clpBNR)].
 :- [library(date_time)].
 
@@ -33,33 +31,35 @@ load_from_string(File, Data, Module) =>
 % - Maybe we don't need the recursion level.
 
 :- leash(-all).
-:- visible(-all), visible([+exit, +fail]).
+:- visible(-all).
+:- visible([+exit, +fail]).
 
 :- dynamic log_stack_frame/1.
 
 prolog_trace_interception(Port, Frame, _Choice, continue) :-
-  prolog_frame_attribute(Frame, goal, Current_goal),
-  prolog_frame_attribute(Frame, level, Recursion_level),
+  prolog_frame_attribute(Frame, goal, CurrentGoal),
+  prolog_frame_attribute(Frame, level, RecursionLevel),
 
-  prolog_frame_attribute(Frame, parent_goal(Parent_frame), Current_goal),
-  prolog_frame_attribute(Parent_frame, goal, Parent_goal),
+  prolog_frame_attribute(Frame, parent_goal(ParentFrame), CurrentGoal),
+  prolog_frame_attribute(ParentFrame, goal, ParentGoal),
 
   StackFrame = stack_frame{
-    current_goal:Current_goal,
-    parent_goal:Parent_goal,
+    current_goal:CurrentGoal,
+    parent_goal:ParentGoal,
     port:Port,
-    recursion_depth:Recursion_level
+    recursion_depth:RecursionLevel
   },
 
   log_stack_frame(StackFrame).
 
-% #define(
-%   toggle_tracing(Toggle0, Goal, Toggle1),
-%   (Toggle0, setup_call_cleanup(true, call(Goal), Toggle1))
-% ).
+run_query(StackTrace, Query) =>
+  setup_call_cleanup(
+    asserta(stack_trace(StackTrace)),
 
-once_trace_all(Goal) =>
-  setup_call_cleanup(trace, once(Goal), notrace).
+    setup_call_cleanup(trace, once(Query), notrace),
+
+    retract(stack_trace(StackTrace))
+  ).
 
 % https://www.swi-prolog.org/pldoc/man?predicate=op/3
 :- op(700, xfx, eq).

--- a/public/resources/swipl/prelude.pl
+++ b/public/resources/swipl/prelude.pl
@@ -52,7 +52,7 @@ prolog_trace_interception(Port, Frame, _Choice, continue) :-
 
   log_stack_frame(StackFrame).
 
-run_query(StackTrace, Query) =>
+query_and_trace(StackTrace, Query) =>
   setup_call_cleanup(
     asserta(stack_trace(StackTrace)),
 

--- a/src/l4_lp/swipl/js/wasm_query.cljs
+++ b/src/l4_lp/swipl/js/wasm_query.cljs
@@ -11,39 +11,29 @@
 (def ^:private prelude-qlf-url
   "resources/swipl/prelude.qlf")
 
-(defn- fn->non-plain-obj [f]
-  (new #(this-as this (jsi/assoc! this :apply f))))
+(defn- swipl-query-once
+  [swipl & args]
+  (it-> swipl
+        (apply jsi/call-in it [:prolog :query] args)
+        (jsi/call it :once)))
 
 (defn- run-swipl-query! [swipl query]
   (prom/let
-   [stack-trace (transient [])
-
-    ;; Need to wrap functions by an opaque, non-plain JS object with a method
-    ;; that runs the original function.
-    ;; This is because if we pass in a plain object, or plain lambda, swipl-wasm
+   [stack-trace #js []
+    ;; Wrap the stack-trace in a non-plain JS object.
+    ;; Note that if we pass in a plain object, or plain lambda, swipl-wasm
     ;; treats them both as plain objects and tries to recursively convert it to
     ;; a Prolog dictionary, which fails.
-    log-stack-frame-callback
-    (fn->non-plain-obj #(conj! stack-trace %))
-
-    swipl-call-once (fn [& args]
-                      (it-> swipl
-                            (apply jsi/call-in it [:prolog :query] args)
-                            (jsi/call it :once)))
-
-    _ (swipl-call-once "asserta(js_log_stack_frame_callback(Func))"
-                       #js {:Func log-stack-frame-callback})
-
-    query-result (swipl-call-once (str "once_trace_all(" query ")"))
-
-    _ (swipl-call-once "retractall(js_log_stack_frame_callback(_))")]
-
+    stack-trace-obj
+    (new #(this-as this (jsi/assoc! this :log_stack_frame
+                                    (partial jsi/call stack-trace :push))))
+    query-result
+    (swipl-query-once swipl
+                      (str "run_query(StackTrace," query ")")
+                      #js {:StackTrace stack-trace-obj})]
     {:query query
-     :bindings (-> query-result
-                   swipl-js->clj/swipl-query-result->bindings)
-     :trace (-> stack-trace
-                persistent!
-                swipl-js->clj/swipl-stack-trace->clj)}))
+     :bindings (-> query-result swipl-js->clj/swipl-query-result->bindings)
+     :trace (-> stack-trace swipl-js->clj/swipl-stack-trace->clj)}))
 
 (defn query-and-trace!
   ([prolog-program+queries]
@@ -60,8 +50,8 @@
     ;; Doing so results in a runtime error.
      _ (jsi/call-in swipl [:prolog :load_string]
                     "log_stack_frame(StackFrame) =>
-                      js_log_stack_frame_callback(Func),
-                      _ := Func.apply(StackFrame).")
+                       stack_trace(StackTrace),
+                       _ := StackTrace.log_stack_frame(StackFrame).")
 
      _ (jsi/call-in swipl [:prolog :consult] prelude-qlf-url)
      _ (jsi/call-in swipl [:prolog :load_string] program)]

--- a/src/l4_lp/swipl/js/wasm_query.cljs
+++ b/src/l4_lp/swipl/js/wasm_query.cljs
@@ -29,7 +29,7 @@
                                     (partial jsi/call stack-trace :push))))
     query-result
     (swipl-query-once swipl
-                      (str "run_query(StackTrace," query ")")
+                      (str "query_and_trace(StackTrace," query ")")
                       #js {:StackTrace stack-trace-obj})]
     {:query query
      :bindings (-> query-result swipl-js->clj/swipl-query-result->bindings)

--- a/src/l4_lp_py/swipl/_query.py
+++ b/src/l4_lp_py/swipl/_query.py
@@ -34,7 +34,7 @@ def _query_and_trace(prolog_program_and_queries):
         stack_trace = _StackTrace()
 
         janus.query_once(
-          f'run_query(StackTrace, {query})',
+          f'query_and_trace(StackTrace, {query})',
           {'StackTrace': stack_trace}
         )
 

--- a/src/l4_lp_py/swipl/_query.py
+++ b/src/l4_lp_py/swipl/_query.py
@@ -34,13 +34,9 @@ def _query_and_trace(prolog_program_and_queries):
         stack_trace = _StackTrace()
 
         janus.query_once(
-          'asserta(py_stack_trace(PyStackTrace))',
-          {'PyStackTrace': stack_trace}
+          f'run_query(StackTrace, {query})',
+          {'StackTrace': stack_trace}
         )
-
-        janus.query_once(f'once_trace_all({query})')
-
-        janus.query_once('retractall(py_stack_trace(_))')
 
         yield {'query': query, 'stack_trace': stack_trace.get()}
 

--- a/src/l4_lp_py/swipl/prolog/prelude.pl
+++ b/src/l4_lp_py/swipl/prolog/prelude.pl
@@ -1,12 +1,13 @@
-:- ['../../../../public/resources/swipl/prelude'].
 :- use_module(library(janus)).
 
-:- dynamic py_stack_trace/1.
+:- ['../../../../public/resources/swipl/prelude'].
+
+:- dynamic stack_trace/1.
 
 log_stack_frame(StackFrame) =>
   py_transform_compound_term(StackFrame, TransformedStackFrame),
-  py_stack_trace(PyStackTrace),
-  py_call(PyStackTrace:log_stack_frame(TransformedStackFrame)).
+  stack_trace(StackTrace),
+  py_call(StackTrace:log_stack_frame(TransformedStackFrame)).
 
 py_transform_compound_term(InString, OutTaggedDict), string(InString) =>
   OutTaggedDict = py{'$t': s, v: InString}.
@@ -29,10 +30,8 @@ py_transform_compound_term(InDict, OutDict), is_dict(InDict) =>
   maplist(py_transform_compound_term, InVals, OutVals),
   pairs_keys_values(OutPairs, OutKeys, OutVals),
   dict_pairs(OutDict, Tag, OutPairs).
-  % OutTaggedDict = py{'TYPE':dict, 'DICT':OutDict}.
 
 py_transform_compound_term(InCompoundTerm, OutDict) =>
   InCompoundTerm =.. [Functor | Args],
   maplist(py_transform_compound_term, Args, OutArgs),
   dict_pairs(OutDict, py, ['$t'-t, functor-Functor, Functor-OutArgs]).
-  % OutTaggedDict = py{'TYPE':compound_term, 'FUNCTOR':Functor, 'ARGS':OutArgs}.


### PR DESCRIPTION
- We provide a new top-level `query_and_trace(StackTrace, Query)` predicate for running and tracing queries from Clojurescript and Python. Note that:
  - Compared to the previous `query_trace_all` predicate, this new predicate now takes an extra `StackTrace` argument.
  - This argument is assumed to be a JS / Python object (depending on the host platform) that has a `log_stack_frame` method which is in turn assumed to mutate the object by appending a new stack frame to it.
    - This unifies the structure of the `StackTrace` object across the supported host platforms. Previously, such objects had a slightly different (and hence inconsistent) structure on JS vs Python.
  - Unlike `query_trace_all`, this predicate also asserts and retracts `stack_trace(StackTrace)` so that callers from JS and Python don't need to do that themselves anymore.
- The Clojurescript `run-swipl-query!` and Python `query_and_trace` functions have been adjusted to accomodate the above changes.
- Stack trace objects in Clojurescript are now backed by JS arrays, as opposed to transient vectors. This is done for simplicity and performance, since we never need persistent versions of those vectors.