### PR TITLE
Reuse the same swipl wasm interpreter across multiple IDE query runs.

### DIFF
--- a/src/l4_lp/ide/browser_backend/core.cljs
+++ b/src/l4_lp/ide/browser_backend/core.cljs
@@ -1,11 +1,12 @@
 (ns l4-lp.ide.browser-backend.core 
   (:require [applied-science.js-interop :as jsi]
             [lambdaisland.uri :as uri]
-            [meander.epsilon :as m]))
+            [meander.epsilon :as m]
+            [l4-lp.swipl.js.wasm-query :as swipl-wasm-query]))
 
 (def ^:private swipl-prelude-qlf-url
   (let [app-url (jsi/get-in js/window [:location :href])]
-    (str (uri/join app-url "./resources/swipl/prelude.qlf"))))
+    (str (uri/join app-url swipl-wasm-query/swipl-prelude-qlf-relative-url))))
 
 (def ^:private no-op
   (constantly nil))
@@ -13,12 +14,12 @@
 (def worker-js-url
   "./js/l4_ide/worker.js")
 
-(def swipl-prelude-url-data
-  #js {:tag "swipl-prelude-qlf-url"
+(def init-swipl-data
+  #js {:tag "init-swipl-with-prelude-url"
        :payload swipl-prelude-qlf-url})
 
-(defn l4-program->worker-data [l4-program]
-  #js {:tag "l4-program"
+(defn l4-program->run-query-data [l4-program]
+  #js {:tag "run-l4-query"
        :payload l4-program})
 
 (defn on-data-from-worker


### PR DESCRIPTION
This change is aimed at reducing the delay between the moment a query is sent to the wasm based swi prolog backend, and the moment it responds with a query. This in turn helps to improve the speed of query execution in the IDE.

The tradeoff though is that we incur slightly increased CPU and memory usage, because briefly, we would start up and stop a Prolog interpreter instance whenever we loaded a transpiled Prolog program and executed queries on it.
Now, we eliminate this overhead by instead loading up one such instance for the duration of the lifespan of the IDE, and re-use it across all query runs. This interpreter instance is never shut down in between queries and consumes additional resources in the background.

As for the technical details, previously, whenever `query-and-trace!` (in `l4-lp.ide.swipl.js.wasm-query`) was called to execute queries on a Prolog program, it would, in the following order:
1. Initialise a new swipl interpreter.
2. Load up our predefined predicates in `public/resources/swipl/prelude.qlf`.
3. Load up the Prolog program
4. Execute the queries
5. Shut down the interpreter
This means that every time we want to execute a query, we incur the small but still noticeable overhead of starting and stopping the swipl interpreter, as well as loading up our prelude (which does not change at runtime).
This was done because at the time, I was unaware of a way to sandbox predicates and clauses defined in a program, or to unload them before loading up a new program.

After some investigation, I stumbled upon [this](https://swi-prolog.discourse.group/t/using-the-wasm-version/6379/2) post from the swipl forums, which suggests that one can effectively unload and reload a Prolog program by using the same, fixed file Id when calling `Prolog.consult_string(String, Id)`.

The `query-and-trace!` function has now been refactored so that:
- It now allows for a swipl interpreter object to be passed into it, so that this can be fixed and remain unchanged across multiple query runs. (One can use the new `init-swipl!` function in the same `l4-lp.ide.swipl.js.wasm-query` for this)
- program strings are now loaded via `Prolog.load_string` with a fixed file Id of `"id"`.
Alongside this change, the browser web worker used in the IDE's backend has been adapted to initialise a single swipl interpreter instance for its lifetime, which is then reused whenever it runs queries via `query-and-trace!`.

As mentioned, this means that the browser backend now runs a swipl interpreter persistently in the background, which is never shut down after a query completes. This differs from the previous behaviour, where the interpreter shuts down after queries execute. Consequently, users can expect increased CPU and memory usage, though I find that in practice, this is small enough, and a worthwhile tradeoff for improved query performance.