### PR TITLE
Improve query button text visibility

### DIFF
--- a/src/l4_lp/ide/ui/query/button.cljs
+++ b/src/l4_lp/ide/ui/query/button.cljs
@@ -7,6 +7,7 @@
            button-props children]}]
   (uix/$ LoadingButton
          (merge button-props
-                {:loading loading?
+                {:color :secondary
+                 :loading loading?
                  :on-click on-click})
          children))


### PR DESCRIPTION
Tweaks the color of the query button so that the "run queries" text inside it is more visible.
Previously, the button was grey, so that the white text was hard to read. It is now purple so that the white text is more prominent.